### PR TITLE
Include only necessary files on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "main": "lib/index.js",
   "license": "MIT",
   "author": "Sara Vieira",
+  "files": [
+    "lib",
+    "Readme.md",
+    "package.json",
+    "yarn.lock"
+  ],
   "scripts": {
     "start": "styleguidist server",
     "build": "styleguidist build",


### PR DESCRIPTION
This PR will explicitly specify the `files` to be added in the package when published to `npm`.